### PR TITLE
Fix calling ExecTypedContext w/o timeout

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -322,7 +322,7 @@ func (conn *Connection) ExecContext(ctx context.Context, req *Request) (*Respons
 
 // Exec Request with context.Context and decode it to typed result.
 func (conn *Connection) ExecTypedContext(ctx context.Context, req *Request, result interface{}) error {
-	if _, ok := ctx.Deadline(); !ok {
+	if _, ok := ctx.Deadline(); !ok && conn.opts.RequestTimeout > 0 {
 		var cancel func()
 		ctx, cancel = context.WithTimeout(ctx, conn.opts.RequestTimeout)
 		defer cancel()

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/FZambia/tarantool
 
 go 1.15
 
-require github.com/vmihailenco/msgpack/v5 v5.1.0
+require (
+	github.com/stretchr/testify v1.6.1
+	github.com/vmihailenco/msgpack/v5 v5.1.0
+)

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=


### PR DESCRIPTION
Calling `ExecTypedContext` with `context.Backgroud` leads to executing request with timeout 0, so long requests fail.