### PR TITLE
Add DisableArrayEncodedStructs option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is an opinionated modification of [github.com/tarantool/go-tarantool](https
 
 * API changed, some non-obvious (mostly to me personally) API removed.
 * This package uses the latest msgpack library [github.com/vmihailenco/msgpack/v5](https://github.com/vmihailenco/msgpack) instead of `v2` in original.
-* Uses `enc.UseArrayEncodedStructs(true)` for `msgpack.Encoder` internally so there is no need to define `msgpack:",as_array"` struct tags.
+* Uses `enc.UseArrayEncodedStructs(true)` for `msgpack.Encoder` by default so there is no need to define `msgpack:",as_array"` struct tags. If you need to disable this (for example when using nested structs) then this behavior can be disabled using `DisableArrayEncodedStructs` option.
 * Supports out-of-bound pushes (see [box.session.push](https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_session/#box-session-push))
 * Adds optional support for `context.Context` (though performance will suffer a bit, if you want a maximum performance then use non-context methods which use per-connection timeout). Context cancellation does not cancel a query (Tarantool has no such functionality) - just stops waiting for request future resolving.
 * Uses sync.Pool for `*msgpack.Decoder` to reduce allocations on decoding stage a bit. Actually this package allocates a bit more than the original one, but allocations are small and overall performance is comparable to the original (based on observations from internal benchmarks). 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,18 @@
+v0.2.3
+======
+
+* Add `DisableArrayEncodedStructs` option.
+
+```
+> gorelease -base v0.2.2 -version v0.2.3
+github.com/FZambia/tarantool
+----------------------------
+Compatible changes:
+- Opts.DisableArrayEncodedStructs: added
+
+v0.2.3 is a valid semantic version for this release.
+```
+
 v0.2.2
 ======
 

--- a/connection.go
+++ b/connection.go
@@ -195,6 +195,10 @@ type Opts struct {
 	// Logger is user specified logger used for log messages.
 	Logger Logger
 
+	// DisableArrayEncodedStructs allows disabling usage of UseArrayEncodedStructs option
+	// of msgpack Encoder.
+	DisableArrayEncodedStructs bool
+
 	network string
 	address string
 }
@@ -867,7 +871,7 @@ func (conn *Connection) putFuture(fut *futureImpl, body func(*msgpack.Encoder) e
 	if cap(shard.buf) == 0 {
 		shard.buf = make(smallWBuf, 0, 128)
 		enc := msgpack.NewEncoder(&shard.buf)
-		enc.UseArrayEncodedStructs(true)
+		enc.UseArrayEncodedStructs(!conn.opts.DisableArrayEncodedStructs)
 		shard.enc = enc
 	}
 	bufLen := len(shard.buf)


### PR DESCRIPTION
`UseArrayEncodedStructs` encodes nested structs too, which is not the desired behavior in some cases. Here we introduce an option to disable using `UseArrayEncodedStructs` of msgpack.Encoder.